### PR TITLE
Improve Dropdown API transparency and add wrapper for DropdownToggle

### DIFF
--- a/frontend/packages/console-app/src/components/oauth-config/OAuthConfigDetails.tsx
+++ b/frontend/packages/console-app/src/components/oauth-config/OAuthConfigDetails.tsx
@@ -11,7 +11,7 @@ import {
 } from '@console/internal/components/utils';
 import { ClusterOperatorModel } from '@console/internal/models';
 import { OAuthKind } from '@console/internal/module/k8s';
-import { Dropdown } from '@console/shared/src/components/dropdown';
+import { Dropdown, DropdownToggle } from '@console/shared/src/components/dropdown';
 import { IDP_TYPES } from '@console/shared/src/constants/auth';
 import { useQueryParams } from '@console/shared/src/hooks/useQueryParams';
 import { IdentityProviders } from './IdentityProviders';
@@ -107,9 +107,21 @@ export const OAuthConfigDetails: React.FC<OAuthDetailsProps> = ({ obj }: { obj: 
             </>
           </Alert>
         )}
-        <Dropdown id="idp" dropdownItems={IDPDropdownItems}>
-          {t('console-app~Add')}
-        </Dropdown>
+        <Dropdown
+          toggle={
+            <DropdownToggle
+              id="idp-dropdown"
+              onToggle={() => setIDPOpen(!isIDPOpen)}
+              data-test-id="dropdown-button"
+            >
+              {t('console-app~Add')}
+            </DropdownToggle>
+          }
+          isOpen={isIDPOpen}
+          dropdownItems={IDPDropdownItems}
+          onSelect={() => setIDPOpen(false)}
+          id="idp"
+        />
         <IdentityProviders identityProviders={identityProviders} />
       </div>
     </>

--- a/frontend/packages/console-shared/src/components/dropdown/DefaultDropdown.tsx
+++ b/frontend/packages/console-shared/src/components/dropdown/DefaultDropdown.tsx
@@ -1,41 +1,23 @@
 import * as React from 'react';
-import {
-  MenuToggle as PFMenuToggle,
-  MenuToggleElement as PFMenuToggleElement,
-  Dropdown as PFDropdown,
-  DropdownList as PFDropdownList,
-} from '@patternfly/react-core';
+import { Dropdown as PFDropdown, DropdownList, MenuToggleElement } from '@patternfly/react-core';
 
-const Dropdown: React.FC<DropdownProps> = ({ dropdownItems, id, children }) => {
-  const [isOpen, setIsOpen] = React.useState(false);
-
-  const onToggleClick = () => {
-    setIsOpen(!isOpen);
-  };
-
-  const onSelect = () => {
-    setIsOpen(false);
-  };
-
+const Dropdown: React.FC<DropdownProps> = ({ dropdownItems, children, ...props }) => {
+  const toggle = React.useCallback(
+    (ref: React.RefObject<MenuToggleElement>) => React.cloneElement(props.toggle, { ref }),
+    [props.toggle],
+  );
   return (
-    <PFDropdown
-      onSelect={onSelect}
-      isOpen={isOpen}
-      id={id}
-      onOpenChange={(isDropdownOpen: boolean) => setIsOpen(isDropdownOpen)}
-      toggle={(toggleRef: React.Ref<PFMenuToggleElement>) => (
-        <PFMenuToggle ref={toggleRef} onClick={onToggleClick} isExpanded={isOpen}>
-          {children}
-        </PFMenuToggle>
-      )}
-    >
-      <PFDropdownList>{dropdownItems}</PFDropdownList>
+    <PFDropdown toggle={toggle} {...props}>
+      {dropdownItems ? <DropdownList>{dropdownItems}</DropdownList> : children}
     </PFDropdown>
   );
 };
 
 type DropdownProps = {
-  dropdownItems: any[];
+  onSelect: (e: React.MouseEvent<Element, MouseEvent>) => void;
+  isOpen: boolean;
+  toggle: React.ReactElement;
+  dropdownItems?: React.ReactNode[]; // Optional so that we can also use children as dropdown content
   id: string;
 };
 

--- a/frontend/packages/console-shared/src/components/dropdown/DropdownToggle.tsx
+++ b/frontend/packages/console-shared/src/components/dropdown/DropdownToggle.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { MenuToggle, MenuToggleElement } from '@patternfly/react-core';
+
+const DropdownToggle = React.forwardRef(
+  (props: DropdownToggleProps, ref: React.RefObject<MenuToggleElement>) => (
+    <MenuToggle innerRef={ref} {...props} />
+  ),
+);
+
+type DropdownToggleProps = {
+  id: string;
+  onToggle: () => void;
+  'data-test-id': string;
+  children?: React.ReactNode;
+};
+
+export default DropdownToggle;

--- a/frontend/packages/console-shared/src/components/dropdown/index.ts
+++ b/frontend/packages/console-shared/src/components/dropdown/index.ts
@@ -1,3 +1,4 @@
 export { default as DropdownWithSwitch } from './dropdown-with-switch/DropdownWithSwitch';
 export { default as ResourceDropdown } from './ResourceDropdown';
 export { default as Dropdown } from './DefaultDropdown';
+export { default as DropdownToggle } from './DropdownToggle';


### PR DESCRIPTION
This will minimize the changes needed when replacing the usage of DropdownDeprecated and DropdownToggleDeprecated with the new shared wrapper components.